### PR TITLE
Style/lucas/content card image

### DIFF
--- a/MKW/src/app/shared/components/content-card/content-card.component.scss
+++ b/MKW/src/app/shared/components/content-card/content-card.component.scss
@@ -5,12 +5,15 @@
   flex-wrap: nowrap;
   border-bottom: 2px solid #e2e2e2;
   font-family: 'Poppins', sans-serif;
+
   .content-poster {
+    min-width: 35vw;
     width: 35vw;
     height: 53.5vw;
     margin-right: .5rem;
     filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
   }
+
   article {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
# Add min-width to content-card image

# Add minimum width to content card's image, because when the content loads, it is possible that sometimes the image will load a few ms later, and it gets clear when the layout of the component changes. With the minimun-width, there is no layout changing.